### PR TITLE
Fix invalid value of $this inside callback

### DIFF
--- a/src/PhalconDebugbar.php
+++ b/src/PhalconDebugbar.php
@@ -261,8 +261,9 @@ class PhalconDebugbar extends DebugBar {
 		if ( $backend instanceof Multiple || $backend instanceof Backend ) {
 			if ($this->shouldCollect('cache',false)) {
 				$this->di->remove($cacheService);
-				$this->di->set($cacheService, function()use($backend,$collector){
-					return $this->createProxy(clone $backend,$collector);
+				$self = $this;
+				$this->di->set($cacheService, function()use($self,$backend,$collector){
+					return $self->createProxy(clone $backend,$collector);
 				}); }
 		}
 	}


### PR DESCRIPTION
Starting from Phalcon 2.1, the DI container callbacks are bound to their own instance.
Fixes #28
