### PR TITLE
Fix db query variable show

### DIFF
--- a/src/Phalcon/Db/Profiler.php
+++ b/src/Phalcon/Db/Profiler.php
@@ -72,6 +72,10 @@ class Profiler extends  PhalconProfiler {
 		$this->handleFailed();
 		$activeProfile = new Item();
 
+		if( !$sqlVariables )  {
+            		$sqlVariables = $this->_db->getSqlVariables();
+		}
+
 		$activeProfile->setSqlStatement($sqlStatement);
 		$activeProfile->setRealSQL($this->getRealSql($sqlStatement,$sqlVariables,$sqlBindTypes));
 
@@ -97,7 +101,7 @@ class Profiler extends  PhalconProfiler {
 
     public function getRealSql( $sql, $variables, $sqlBindTypes ) {
         if ( !$variables ) {
-	    $variables = $this->_db->getSqlVariables();
+	    return $sql;
         }
         $pdo = $this->_db->getInternalHandler();
         $indexes = array();


### PR DESCRIPTION
On the last patch multiple warnings appear when no binds are set on the query. This patch fix it.