### PR TITLE
[BUG] get_class() expects parameter 1 to be object

### DIFF
--- a/src/DataCollector/RouteCollector.php
+++ b/src/DataCollector/RouteCollector.php
@@ -56,7 +56,7 @@ class RouteCollector extends DataCollector implements Renderable {
 			}
 		}else{
 			$result['Moudle']=$router->getModuleName();
-			$result['Controller'] = get_class( $controller_instance = $dispatcher->getActiveController());
+			$result['Controller'] = $dispatcher->getActiveController() != null ? get_class( $controller_instance = $dispatcher->getActiveController()) : $controller_instance ="";
 			$result['Action']     = $dispatcher->getActiveMethod();
 			$reflector = new \ReflectionMethod($controller_instance, $result['Action']);
 		}


### PR DESCRIPTION
With PHP7.0.30, we have a warning bug :
( ! ) Warning: get_class() expects parameter 1 to be object, null given in /usr/share/nginx/html/projectname/vendor/snowair/phalcon-debugbar/src/DataCollector/RouteCollector.php on line 59

Bug Line :
$result['Controller'] = get_class( $controller_instance = $dispatcher->getActiveController());

Fix :
$result['Controller'] = $dispatcher->getActiveController() != null ? get_class( $controller_instance = $dispatcher->getActiveController()) : $controller_instance ="";