### PR TITLE
Corresponds to responses other than html or json

### DIFF
--- a/src/PhalconDebugbar.php
+++ b/src/PhalconDebugbar.php
@@ -631,8 +631,10 @@ PROXY_CLASS;
             ) {
                 $data = $this->collect();
                 $content = json_decode($response->getContent(), true);
-                $data = array_merge($data, $content);
-                $response->setContent(json_encode($data));
+                if (!is_null($content)) {
+                    $data = array_merge($data, $content);
+                    $response->setContent(json_encode($data));
+                }
             } elseif ($config->get('inject', true)) {
                 $response->setHeader('Phalcon-Debugbar', 'on');
                 $this->injectDebugbar($response);


### PR DESCRIPTION
When returning data such as csv as a response, json_encode failed, so if decoding could not be done, it will be returned as it is.